### PR TITLE
add check for ruby 1.8.7 or lower

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -328,7 +328,12 @@ module CanCan
     def alternative_subjects(subject)
       subject = subject.class unless subject.is_a?(Module)
       descendants = []
-      [:all, *subject.ancestors, *descendants, subject.class.to_s]
+
+      unless RUBY_VERSION <= "1.8.7"
+        [:all, *subject.ancestors, *descendants, subject.class.to_s]
+      else
+        [:all] + subject.ancestors + descendants + [subject.class.to_s]
+      end
     end
 
     # Returns an array of Rule instances which match the action and subject


### PR DESCRIPTION
I think this should fix the issue with the splat blowing up 1.8.7.
